### PR TITLE
Feat time monotonic clock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: Go Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: ${{ github.repository }}
+      - name: Set up Go
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version: 1.24
+      - name: Install dependencies
+        run: go mod tidy
+      - name: Run tests
+        run: go test ./... -v

--- a/clock/clock.go
+++ b/clock/clock.go
@@ -1,0 +1,24 @@
+package clock
+
+import (
+	"fmt"
+	"time"
+)
+
+type Clock struct {
+	Hour   int
+	Minute int
+	Second int
+	Time   time.Time
+}
+
+func NewClock(t time.Time) *Clock {
+	h, m, s := t.Hour(), t.Minute(), t.Second()
+	fmt.Printf("new clock; %s\n", t)
+	return &Clock{
+		Hour:   h,
+		Minute: m,
+		Second: s,
+		Time:   t.Truncate(0),
+	}
+}

--- a/clock/clock_test.go
+++ b/clock/clock_test.go
@@ -1,0 +1,40 @@
+package clock_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/tkdn/go-sandbox/clock"
+)
+
+func TestNewClockEquality(t *testing.T) {
+	testCases := []struct {
+		name     string
+		testTime time.Time
+	}{
+		{
+			name:     "time.Date",
+			testTime: time.Date(2025, 12, 15, 17, 00, 30, 123456789, time.UTC),
+		},
+		{
+			name:     "time.Now",
+			testTime: time.Now(),
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, want := clock.NewClock(tc.testTime), &clock.Clock{
+				Hour:   tc.testTime.Hour(),
+				Minute: tc.testTime.Minute(),
+				Second: tc.testTime.Second(),
+				Time:   tc.testTime,
+			}
+
+			if err := cmp.Diff(got, want); err != "" {
+				t.Errorf("\ngot: %+v\nwant: %+v\n", got, want)
+			}
+
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/tkdn/go-sandbox
 
 go 1.24
+
+require github.com/google/go-cmp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=


### PR DESCRIPTION
monotonic clock が macOS で省略されるケースがあるが手元で再現がむずかしい。本PRでやってみたが再現せずそのままマージする